### PR TITLE
Fixing comment to mention correct driver version

### DIFF
--- a/example-4x/src/main/java/com/datastax/samples/SampleCode4x_CRUD_00_GettingStarted.java
+++ b/example-4x/src/main/java/com/datastax/samples/SampleCode4x_CRUD_00_GettingStarted.java
@@ -20,8 +20,8 @@ import com.datastax.oss.driver.api.querybuilder.QueryBuilder;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 
 /**
- * Sample codes using Cassandra OSS Driver 3.x
- * 
+ * Sample codes using Cassandra OSS Driver 4.x
+ *
  * Disclaimers:
  *  - Tests for arguments nullity has been removed for code clarity
  *  - Packaged as a main class for usability

--- a/example-4x/src/main/java/com/datastax/samples/SampleCode4x_CRUD_07_ObjectMapping.java
+++ b/example-4x/src/main/java/com/datastax/samples/SampleCode4x_CRUD_07_ObjectMapping.java
@@ -20,7 +20,7 @@ import com.datastax.samples.objectmapping.CommentDao;
 import com.datastax.samples.objectmapping.CommentDaoMapper;
 
 /**
- * Sample codes using Cassandra OSS Driver 3.x
+ * Sample codes using Cassandra OSS Driver 4.x
  * 
  * Disclaimers:
  *  - Tests for arguments nullity has been removed for code clarity


### PR DESCRIPTION
Just fixing comment on two `4.x` examples that were mentioning the driver v3 instead of v4